### PR TITLE
debugging grid bin assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Ubuntu 20.04
 ```
-sudo apt install python3-pyshp python3-netcdf4
+sudo apt install python3-pyshp python3-netcdf4 python3-seaborn
 ```


### PR DESCRIPTION
 * use floor() rather than truncating to integer, which is necessary because we have negative latitudes
 * use round() to 6 decimal places to avoid floating point roundoff errors
 * a bit of plotting to help debug start bin assignments

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>